### PR TITLE
Add a case-insensitive BTreeContainer/Folder based on code from nti.containers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,10 +3,11 @@
 =========
 
 
-4.1.1 (unreleased)
+4.2.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Add a case-insensitive but case-preserving BTreeContainer and
+  BTreeFolder.
 
 
 1.4.0 (2024-11-08)

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         'zope.minmax',
         'zope.processlifetime',
         'zope.security',
+        'zope.site',
     ],
     extras_require={
         'test': TESTS_REQUIRE,

--- a/src/nti/zodb/containers.py
+++ b/src/nti/zodb/containers.py
@@ -4,11 +4,18 @@
 Utilities for working with containers, particularly BTree containers.
 """
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
-
-
 import struct
+
+from functools import total_ordering
+from functools import lru_cache
+
+from zope.interface import implementer
+from zope.location.interfaces import ISublocations
+from zope.container.constraints import checkObject
+from zope.container.contained import uncontained
+from zope.container.btree import BTreeContainer
+
+from zope.site.folder import Folder
 
 # ! means network byte order, in case we cross architectures
 # anywhere (doesn't matter), but also causes the sizes to be
@@ -47,3 +54,173 @@ def bit64_int_to_time(value):
     return _double_bits_to_float(_long_to_double_bits(value))[0]
 
 assert bit64_int_to_time(ZERO_64BIT_INT) == 0.0
+
+
+@total_ordering
+class CaseInsensitiveKey:
+    """
+    This class implements a dictionary key that preserves case, but
+    compares case-insensitively. It works with unicode keys only (BTrees do not
+    work if 8-bit and unicode are mixed).
+
+    This is a bit of a heavyweight solution. It is nonetheless optimized for comparisons
+    only with other objects of its same type.
+
+    It must not be subclassed.
+
+    .. versionadded:: NEXT
+    """
+
+    __slots__ = ('key',)
+
+    def __init__(self, key):
+        if not isinstance(key, str):
+            raise TypeError(f'Expected a string, got a {key!r}')
+        self.key = key
+
+    @property
+    def comp_key(self):
+        """
+        Returns the key to compare.
+        """
+        return self.key.casefold()
+
+    def __str__(self):  # pragma: no cover
+        return self.key
+
+    def __repr__(self):  # pragma: no cover
+        return "%s('%s')" % (self.__class__, self.key)
+
+    # These should only ever be compared to themselves
+
+    def __eq__(self, other):
+        try:
+            # pylint: disable=protected-access
+            return other is self or other.comp_key == self.comp_key
+        except AttributeError:  # pragma: no cover
+            return NotImplemented
+
+    def __hash__(self):
+        return hash(self.comp_key)
+
+    def __lt__(self, other):
+        try:
+            # pylint: disable=protected-access
+            return self.comp_key < other.comp_key
+        except AttributeError:  # pragma: no cover
+            return NotImplemented
+
+
+# These work best as plain functions so that the 'self'
+# argument is not captured. The self argument is persistent
+# and so that messes with caches
+@lru_cache(10000)
+def tx_key_insen(key):
+    return CaseInsensitiveKey(key) if key is not None else None
+
+
+class _CheckObjectOnSetMixin(object):
+    """
+    Works only with the standard BTree container.
+    """
+
+    def _setitemf(self, key, value):
+        checkObject(self, key, value)
+        super()._setitemf(key, value)
+
+
+@implementer(ISublocations)
+class CaseInsensitiveBTreeContainer(_CheckObjectOnSetMixin,
+                                    BTreeContainer):
+    """
+    A BTreeContainer that only works with string (unicode) keys, and treats
+    them in a case-insensitive fashion. The original case of the key entered is
+    preserved.
+
+    The underlying BTree is configured for large amounts of data.
+
+    .. versionadded:: NEXT
+    """
+
+    # For speed, we generally implement all these functions directly in terms of the
+    # underlying data; we know that's what the superclass does.
+
+    # Note that the IContainer contract specifies keys that are strings. None
+    # is not allowed.
+
+    assert BTreeContainer._newContainerData
+    def _newContainerData(self):
+        from .btrees import family64LargeBuckets
+        return family64LargeBuckets.OO.BTree() # pylint:disable=no-member
+
+
+    def __contains__(self, key):
+        return  key is not None \
+            and tx_key_insen(key) in self._SampleContainer__data
+
+    def __iter__(self):
+        for k in self._SampleContainer__data:
+            yield k.key
+
+    def __getitem__(self, key):
+        return self._SampleContainer__data[tx_key_insen(key)]
+
+    def get(self, key, default=None):
+        if key is None:
+            return default
+        return self._SampleContainer__data.get(tx_key_insen(key), default)
+
+    def _setitemf(self, key, value):
+        super()._setitemf(tx_key_insen(key), value)
+
+    def __delitem__(self, key):
+        # deleting is somewhat complicated by the need to broadcast
+        # events with the original case
+        l = self._BTreeContainer__len
+        item = self[key]
+        uncontained(item, self, item.__name__)
+        del self._SampleContainer__data[tx_key_insen(key)]
+        l.change(-1) # pylint: disable=no-member
+
+    def items(self, key=None):
+        key = tx_key_insen(key)
+        return ((k.key, v) for k, v in self._SampleContainer__data.items(key))
+
+    def keys(self, key=None):
+        key = tx_key_insen(key)
+        return (k.key for k in self._SampleContainer__data.keys(key))
+
+    def values(self, key=None):
+        key = tx_key_insen(key)
+        return (v for v in self._SampleContainer__data.values(key))
+
+    # pylint:disable=redefined-builtin
+    def iterkeys(self, min=None, max=None, excludemin=False, excludemax=False):
+        if max is None or min is None:
+            return self.keys(min)
+        min = tx_key_insen(min)
+        max = tx_key_insen(max)
+        container = self._SampleContainer__data
+        return (k.key for k in container.keys(min, max, excludemin, excludemax))
+
+    def sublocations(self):
+        # We directly implement ISublocations instead of using the adapter for two reasons.
+        # First, it's much more efficient as it saves the unwrapping
+        # of all the keys only to rewrap them back up to access the data (the adapter
+        # cannot assume the ``.values()`` method, so it has to ``for k in c: yield c[k]``)
+        yield from self._SampleContainer__data.values()
+
+    def clear(self):
+        """
+        Convenience method to clear the entire tree at one time.
+        """
+        if len(self) == 0:
+            return
+        for k in list(self.keys()):
+            del self[k]
+
+class CaseInsensitiveFolder(CaseInsensitiveBTreeContainer,
+                            Folder):
+    """
+    A BTree folder that preserves case but otherwise ignores it.
+    """

--- a/src/nti/zodb/tests/test_containers.py
+++ b/src/nti/zodb/tests/test_containers.py
@@ -11,6 +11,9 @@ from hamcrest import is_
 from hamcrest import has_entry
 from hamcrest import assert_that
 from hamcrest import greater_than
+from hamcrest import has_property
+from hamcrest import none
+from hamcrest import has_length
 
 import struct
 import unittest
@@ -21,8 +24,13 @@ from nti.zodb.containers import time_to_64bit_int
 
 from nti.zodb.tests import SharedConfiguringTestLayer
 
+from nti.testing.matchers import is_true
+from nti.testing.matchers import is_false
+from nti.testing.matchers import validly_provides
+
 family = BTrees.family64
 
+# pylint:disable=unnecessary-dunder-call
 
 class TestContainer(unittest.TestCase):
 
@@ -80,3 +88,101 @@ class TestContainer(unittest.TestCase):
 
             assert_that(struct.unpack(b'!q', qti)[0],
                         is_(i))
+
+class TestCaseInsensitiveBTreeContainer(unittest.TestCase):
+    def _getFUT(self):
+        from ..containers import CaseInsensitiveBTreeContainer as FUT
+        return FUT
+
+    def _makeOne(self):
+        return self._getFUT()()
+
+    def test_provides(self):
+        from zope.container.interfaces import IContainer
+        c = self._makeOne()
+        assert_that(c, validly_provides(IContainer))
+
+    @classmethod
+    def checkCaseContainer(cls, c):
+        from zope.container.contained import Contained as ZContained
+        from zope.location.interfaces import ISublocations
+        child = ZContained()
+        c['UPPER'] = child
+        assert_that(child, has_property('__name__', 'UPPER'))
+
+        assert_that(c.__contains__(None), is_false())
+        assert_that(c.__contains__('UPPER'), is_true())
+        assert_that(c.__contains__('upper'), is_true())
+
+        assert_that(c.__getitem__('UPPER'), is_(child))
+        assert_that(c.__getitem__('upper'), is_(child))
+
+        assert_that(list(iter(c)), is_(['UPPER']))
+        assert_that(list(c.keys()), is_(['UPPER']))
+        assert_that(list(c.keys('a')), is_(['UPPER']))
+        assert_that(list(c.keys('A')), is_(['UPPER']))
+        assert_that(list(c.iterkeys()), is_(['UPPER']))
+
+        assert_that(list(c.items()), is_([('UPPER', child)]))
+        assert_that(list(c.items('a')), is_([('UPPER', child)]))
+        assert_that(list(c.items('A')), is_([('UPPER', child)]))
+
+
+        assert_that(list(c.values()), is_([child]))
+        assert_that(list(c.values('a')), is_([child]))
+        assert_that(list(c.values('A')), is_([child]))
+
+
+        del c['upper']
+        assert_that(c.get(None), is_(none()))
+
+        c['mykey'] = child
+        assert_that(c, has_length(1))
+        del c['MYKEY']
+        assert_that(c, has_length(0))
+
+        c.clear()
+        assert_that(c, has_length(0))
+        c['mykey'] = child
+        assert_that(list(c.iterkeys()), has_length(1))
+        assert_that(list(c.iterkeys('a', 'a')), has_length(0))
+
+        c['otherkey'] = 2 # Some older versions excluded ints from sublocations
+        assert_that(list(c.sublocations()), has_length(2))
+        assert_that(list(ISublocations(c)), has_length(2))
+        c.clear()
+        assert_that(c, has_length(0))
+
+    def test_case_insensitive_container(self):
+        c = self._makeOne()
+        self.checkCaseContainer(c)
+
+    def test_key(self):
+        from ..containers import CaseInsensitiveKey
+        key = CaseInsensitiveKey('UPPER')
+        assert_that(hash(key), is_(hash('upper')))
+
+        assert_that(key.__gt__(CaseInsensitiveKey('z')),
+                    is_(False))
+
+    def test_case_insensitive_container_invalid_keys(self):
+        c = self._makeOne()
+        with self.assertRaises(TypeError):
+            c.get({})
+        with self.assertRaises(TypeError):
+            c.get(1)
+
+class TestCaseInsensitiveFolder(unittest.TestCase):
+    def _getFUT(self):
+        from ..containers import CaseInsensitiveFolder as FUT
+        return FUT
+
+    def _makeOne(self):
+        return self._getFUT()()
+
+    def test_provides(self):
+        from zope.site.interfaces import IFolder
+        assert_that(self._makeOne(), validly_provides(IFolder))
+
+    def test_case_insensitive(self):
+        TestCaseInsensitiveBTreeContainer.checkCaseContainer(self._makeOne())


### PR DESCRIPTION
This has fewer dependencies than nti.containers does.